### PR TITLE
skip extra zero bytes

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,7 +10,12 @@ fn quickcheck_from_vec() {
         match tlv::Tlv::from_vec(&xs) {
             Ok(tlv) => {
                 let restored_tlv = tlv.to_vec();
-                let truncacted_xs = xs.into_iter().take(restored_tlv.len()).collect::<Vec<u8>>();
+
+                let truncacted_xs = xs
+                    .into_iter()
+                    .skip_while(|&x| x == 0)
+                    .take(restored_tlv.len())
+                    .collect::<Vec<u8>>();
 
                 TestResult::from_bool(restored_tlv == truncacted_xs)
             }


### PR DESCRIPTION
Found this issue reading a structure on one particular card I have in my test set.