### PR TITLE
round-trip encoding for extra zero bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ type Result<T> = core::result::Result<T, TlvError>;
 pub enum TlvError {
     TruncatedTlv,
     InvalidLength,
-    InvalidTagNumber,
+    InvalidTagNumber { is_zero: bool },
     TooShortBody { expected: usize, found: usize },
     ValExpected { tag_number: usize },
     TagPathError,
@@ -53,7 +53,7 @@ impl fmt::Display for TlvError {
         match self {
             TruncatedTlv => write!(f, "Too short input vector"),
             InvalidLength => writeln!(f, "Invalid length value"),
-            InvalidTagNumber => write!(f, "Invalid tag number"),
+            InvalidTagNumber { .. } => write!(f, "Invalid tag number"),
             TooShortBody { expected, found } => {
                 write!(f, "Too short body: expected {expected}, found {found}")
             }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,9 +10,9 @@ fn quickcheck_from_vec() {
         match tlv::Tlv::from_vec(&xs) {
             Ok(tlv) => {
                 let restored_tlv = tlv.to_vec();
-                let truncacted_xs = xs.into_iter().take(restored_tlv.len()).collect::<Vec<u8>>();
+                let truncated_xs = xs.into_iter().take(restored_tlv.len()).collect::<Vec<u8>>();
 
-                TestResult::from_bool(restored_tlv == truncacted_xs)
+                TestResult::from_bool(restored_tlv == truncated_xs)
             }
             Err(_) => TestResult::discard(),
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,12 +10,7 @@ fn quickcheck_from_vec() {
         match tlv::Tlv::from_vec(&xs) {
             Ok(tlv) => {
                 let restored_tlv = tlv.to_vec();
-
-                let truncacted_xs = xs
-                    .into_iter()
-                    .skip_while(|&x| x == 0)
-                    .take(restored_tlv.len())
-                    .collect::<Vec<u8>>();
+                let truncacted_xs = xs.into_iter().take(restored_tlv.len()).collect::<Vec<u8>>();
 
                 TestResult::from_bool(restored_tlv == truncacted_xs)
             }


### PR DESCRIPTION
Unfortunately, I've realized that having round-trip encoding of extra zero bytes is important e.g. for being able to correctly compose the DDA data for checking the hash in the decoded ICC certificate.

It's not super elegant to add a fourth field to a "TLV" element, but I don't know a *better* way to do it. And I remembered to update the tests this time...